### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -26,7 +26,7 @@ snakePat	KEYWORD2
 barsPat	KEYWORD2
 randomPat	KEYWORD2
 binaryPat	KEYWORD2
-doubleDecPat    KEYWORD2
+doubleDecPat	KEYWORD2
 
 inc	KEYWORD2
 dec	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords